### PR TITLE
updates for v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### [1.3.3](https://github.com/juliancwirko/elven-tools-cli/releases/tag/v1.3.3) (2022-02-09)
+- bump Smart Contract version after fixes
+- changes in the default gas limits for setting 'drops'
+- removed the limit of 55 tokens per address when deploying, but the mint, giveaway commands will now have max 55 limit per **one** transaction. You can always make more transactions. This will be also improved in the future to be more automatic.
+
 ### [1.3.2](https://github.com/juliancwirko/elven-tools-cli/releases/tag/v1.3.2) (2022-02-08)
 - fix gas limit calculation for the `giveaway` endpoint
 - temporary removed misleading message when issuing the collection token, retrieving the token ticker stopped working after update to erdjs v9 - needs more debugging

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Below is an example of a `.elventoolsrc` config file with default values. It is 
     "giveawayBaseGasLimit": 14000000,
     "giveawayFnName": "giveaway",
     "setDropFnName": "setDrop",
-    "setUnsetDropGasLimit": 12000000,
+    "setUnsetDropGasLimit": 6000000,
     "unsetDropFnName": "unsetDrop",
     "pauseUnpauseGasLimit": 5000000,
     "pauseMintingFnName": "pauseMinting",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elven-tools",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "types": "build/types",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "elvenTools": {
-    "smartContractVersionTagName": "v1.3.0"
+    "smartContractVersionTagName": "v1.3.1"
   },
   "description": "Interacting with custom NFT related Smart Contracts on the Elrond blockchain",
   "main": "build/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,7 +71,7 @@ export const setDropFunctionName =
   customConfig?.config?.nftMinterSc?.setDropFnName || 'setDrop';
 
 export const setUnsetDropTxGasLimit =
-  customConfig?.config?.nftMinterSc?.setUnsetDropGasLimit || 12000000;
+  customConfig?.config?.nftMinterSc?.setUnsetDropGasLimit || 6000000;
 
 export const unsetDropFunctionName =
   customConfig?.config?.nftMinterSc?.unsetDropFnName || 'unsetDrop';
@@ -205,15 +205,15 @@ export const deployNftMinterTagsLabel =
 export const deployNftMinterProvenanceHashLabel =
   'Provide the provenance hash (sha256 hash of all images) [optional]:\n';
 export const deployNftMinterTokensLimitPerAddressLabel =
-  'Total tokens limit per one address per whole collection\nKeep it low. Max 55 because of single transaction gas limits:\n';
+  'Total tokens limit per one address per whole collection (the best is to keep it as low as possible):\n';
 export const deployNftMinterImgExtLabel = 'Provide the file extension:\n';
 
 export const amountOfTokensLabel =
-  'Provide how many tokens should be minted.\nTake into account possible limitations set on the Smart Contract (You need to provide the value which fits in limits as a whole.):\n';
+  'Provide how many tokens should be minted.\nTake into account possible limitations set on the Smart Contract.\nYou need to provide the value which fits in limits as a whole. Max 55 because of the max gas limit per transaction:\n';
 
 export const giveawayAddressLabel = 'Provide the address for giveaway: \n';
 export const giveawayTokensAmount =
-  'Provide how many tokens you want to give away.\nTake into account possible limitations set on the Smart Contract (You need to provide the value which fits in limits as a whole.):\n';
+  'Provide how many tokens you want to give away.\nTake into account possible limitations set on the Smart Contract\nYou need to provide the value which fits in limits as a whole. Max 55 because of the max gas limit per transaction:\n';
 
 export const dropTokensAmountLabel =
   'Provide the amount of the tokens for the drop:\n';
@@ -228,7 +228,7 @@ export const nftSCpayableLabel =
   'Decide if the contract can receive funds. Recommended because of the royalties.\n';
 
 export const dropTokensLimitPerAddressPerDropLabel =
-  'Provide the tokens limit per single address per whole drop (keep it as small as possible) [optional]:\n';
+  'Provide the tokens limit per single address per whole drop (the best is to keep it as low as possible) [optional]:\n';
 
 export const populateIndexesLabel =
   'Provide the amount. By default the max batch size is 5000:\n';

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -120,8 +120,7 @@ const deployNftMinter = async () => {
       type: 'number',
       name: 'deployNftMinterTokensLimitPerAddress',
       message: deployNftMinterTokensLimitPerAddressLabel,
-      validate: (value) =>
-        value && value >= 1 && value <= 55 ? true : 'Min 1; max 55!',
+      validate: (value) => (value && value >= 1 ? true : 'Min 1!'),
     },
     {
       type: 'number',

--- a/src/nft-minter-fns.ts
+++ b/src/nft-minter-fns.ts
@@ -113,7 +113,8 @@ const issueCollectionToken = async () => {
     spinner.start();
 
     await issueCollectionTokenTx.send(provider);
-    await issueCollectionTokenTx.awaitExecuted(provider);
+    // TODO: change to awaitExecuted when token retrive will work
+    await issueCollectionTokenTx.awaitNotarized(provider);
     const txHash = issueCollectionTokenTx.getHash();
 
     // TODO: after updates to erdjs v9 retriving the token stopped working
@@ -175,7 +176,9 @@ const mint = async () => {
       name: 'tokensAmount',
       message: amountOfTokensLabel,
       validate: (value) =>
-        value && value > 0 ? true : 'Required a number greater than 0!',
+        value && value > 0 && value <= 55
+          ? true
+          : 'Required a number greater than 0 and lower than 55 because of the max gas limits!',
     },
   ];
 
@@ -213,7 +216,9 @@ const giveaway = async () => {
       name: 'giveawayTokensAmount',
       message: giveawayTokensAmount,
       validate: (value) =>
-        value && value > 0 ? true : 'Required a number greater than 0!',
+        value && value > 0 && value <= 55
+          ? true
+          : 'Required a number greater than 0 and lower than 55 because of the max gas limits!',
     },
   ];
 


### PR DESCRIPTION
- bump Smart Contract version after fixes
- changes in the default gas limits for setting 'drops'
- removed the limit of 55 tokens per address when deploying, but the mint giveaway commands will now have a max 55 limit per **one** transaction. You can always make more transactions. This will also be improved in the future to be more automatic.